### PR TITLE
Zierman deprecated update

### DIFF
--- a/data/responder.py
+++ b/data/responder.py
@@ -23,11 +23,13 @@ class Responder:
 
     @deprecated
     def send_requested_data(self, connection_socket: socket, requested_data):
+        warn('This is deprecated.', DeprecationWarning)
         connection_socket.settimeout(self.timeout_seconds)
         connection_socket.send(requested_data.encode())
 
     @deprecated
     def send_account_creation_status(self, connection_socket: socket, status):
+        warn('This is deprecated.', DeprecationWarning)
         connection_socket.settimeout(self.timeout_seconds)
         status = '' + status
         connection_socket.send(status.encode())

--- a/data/responder.py
+++ b/data/responder.py
@@ -1,7 +1,7 @@
 from socket import socket
 
 from data.message_item import BaseRequest
-from global_logger import log, VERBOSE, deprecated, log_error
+from global_logger import log, VERBOSE, deprecated, log_error, warn
 
 
 # from MessageItem import MessageItem

--- a/global_logger.py
+++ b/global_logger.py
@@ -171,7 +171,7 @@ class _LoggedWrapperType(Enum):
             return classmethod(_wrapper) if self is _LoggedWrapperType.CLASS_METHOD else _wrapper
 
 
-def logged_function(wrapped = None, level: Optional[int] = None):
+def logged_function(wrapped=None, level: Optional[int] = None):
     """An annotation that allows the annotated function to be logged when called.
 
     Args:

--- a/global_logger.py
+++ b/global_logger.py
@@ -3,13 +3,14 @@ import logging.handlers
 import os
 import pprint
 import time
+import warnings
 from enum import auto, Enum
 from functools import wraps
 from typing import Optional, Union, Callable, Collection
 from util.const import ConstContainer
-
-# Set up logging level constants
 from util.strings import cslist
+
+warn = warnings.warn
 
 
 class LogLevels(ConstContainer):
@@ -25,7 +26,7 @@ CRITICAL = LogLevels.CRITICAL  # 50
 ERROR = LogLevels.ERROR  # 40
 WARNING = LogLevels.WARNING  # 30
 INFO = LogLevels.INFO  # 20
-VERBOSE = LogLevels.VERBOSE # 15
+VERBOSE = LogLevels.VERBOSE  # 15
 DEBUG = LogLevels.DEBUG  # 10
 
 # Setup internal vars

--- a/global_logger.py
+++ b/global_logger.py
@@ -201,6 +201,21 @@ def deprecated(wrapped=None, alternatives: Optional[Union[Callable, Collection[C
     Returns:
         A function that wraps a function
 
+    Notes::
+
+        If you want your IDE to be aware of the deprecation,
+        you may need to manually include a warning within the actual function definition.
+
+        It seems to be that way with PyCharm when creating this.
+
+        My work around is to include the following in the function definition:
+
+            global_logger.warn(<string literal msg>, DeprecationWarning)
+
+            example: global_logger.warn('This is deprecated.', DeprecationWarning)
+
+        It doesn't seem to work using variables for either argument at the moment.
+
     """
 
     def _outer_wrapper(func):

--- a/global_logger.py
+++ b/global_logger.py
@@ -228,7 +228,7 @@ def deprecated(wrapped=None, alternatives: Optional[Union[Callable, Collection[C
         return _outer_wrapper(wrapped)
 
 
-def logged_method(wrapped = None, level: Optional[int] = None):
+def logged_method(wrapped=None, level: Optional[int] = None):
     """An annotation that allows the annotated method to be logged when called.
 
     Args:
@@ -246,7 +246,7 @@ def logged_method(wrapped = None, level: Optional[int] = None):
     return _LoggedWrapperType.NORMAL_METHOD.build_wrapper(wrapped, level)
 
 
-def logged_class_method(wrapped = None, level: Optional[int] = None) -> classmethod:
+def logged_class_method(wrapped=None, level: Optional[int] = None) -> classmethod:
     """An annotation that allows the annotated class method to be logged when called.
 
     Args:

--- a/global_logger.py
+++ b/global_logger.py
@@ -189,6 +189,19 @@ def logged_function(wrapped=None, level: Optional[int] = None):
     return _LoggedWrapperType.FUNCTION.build_wrapper(wrapped, level)
 
 
+def _get_deprecated_msg(func, alternatives: Optional[Union[Callable, Collection[Callable]]] = None):
+    alts = None
+    if alternatives:
+        if isinstance(alternatives, Collection):
+            alts = [f.__name__ for f in alternatives]
+        else:
+            alts = (alternatives.__name__,)
+
+    deprecated_name = func.__name__
+    alt_part_of_msg = '.' if not alts else f", consider using {cslist(alts, conjunction='or')}."
+    return f'{deprecated_name} is deprecated{alt_part_of_msg}'
+
+
 def deprecated(wrapped=None, alternatives: Optional[Union[Callable, Collection[Callable]]] = None) -> Callable:
     """An annotation that logs a warning that the method/function is deprecated.
 
@@ -219,16 +232,7 @@ def deprecated(wrapped=None, alternatives: Optional[Union[Callable, Collection[C
     """
 
     def _outer_wrapper(func):
-        alts = None
-        if alternatives:
-            if isinstance(alternatives, Collection):
-                alts = [f.__name__ for f in alternatives]
-            else:
-                alts = (alternatives.__name__,)
-
-        deprecated_name = func.__name__
-        alt_part_of_msg = '.' if not alts else f", consider using {cslist(alts, conjunction='or')}."
-        msg = f'{deprecated_name} is deprecated{alt_part_of_msg}'
+        msg = _get_deprecated_msg(func, alternatives)
 
         def _wrapper(*args, **kwargs):
             _logger.warning(msg)


### PR DESCRIPTION
Changes:
- Changes to documentation
  - Added notes to docstring to address issue with IDE recognition of deprecated functions/methods. (see issue #29)
  - Added example of how to work around the previously mentioned issue.
- Created `global_logger.warn` (used in the previously mentioned workaround).
- Extracted a private helper method to create the depreciated warning message, but unfortunately it can't be used with the workaround previously mentioned. 
- Implemented the workaround previously mentioned for the currently deprecated methods.

All previously passing tests still pass with these changes. No changes to tests where needed with these changes.